### PR TITLE
[DEV-247] 강의 직접 추가 api 시간표 추가 안됨 버그

### DIFF
--- a/src/main/java/community/mingle/api/domain/course/facade/CourseFacade.java
+++ b/src/main/java/community/mingle/api/domain/course/facade/CourseFacade.java
@@ -47,7 +47,7 @@ public class CourseFacade {
             throw new CustomException(TIMETABLE_CONFLICT);
         }
 
-        courseService.createPersonalCourse(
+        PersonalCourse personalCourse = courseService.createPersonalCourse(
                 request.courseCode(),
                 request.name(),
                 request.courseTimeDtoList(),
@@ -57,6 +57,8 @@ public class CourseFacade {
                 member.getUniversity(),
                 member
         );
+
+        timetableService.addCourse(timetable, personalCourse);
 
         return new CreatePersonalCourseResponse(
                 request.name(),


### PR DESCRIPTION
강의 직접추가 api 에서 강의가 course 테이블에는 추가가 되지만 파라미터로 받은 timetable에 대해서 course_timetable 테이블에 매핑이 되지 않고 있었음