### PR TITLE
[DEV-271] 게시물 전체 리스트 API

### DIFF
--- a/src/main/java/community/mingle/api/domain/post/controller/PostController.java
+++ b/src/main/java/community/mingle/api/domain/post/controller/PostController.java
@@ -48,6 +48,14 @@ public class PostController {
         return new ResponseEntity<>(createPostResponse, HttpStatus.OK);
     }
 
+    @Operation(summary = "게시물 전체글 리스트 API")
+    @GetMapping("/{boardType}/all")
+    public ResponseEntity<PostListResponse> AllPosts(@PathVariable BoardType boardType, @Parameter Pageable pageable) {
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.Direction.DESC, "createdAt");
+        PostListResponse postPreviewList = postFacade.getAllPostList(boardType, pageRequest);
+        return ResponseEntity.ok().body(postPreviewList);
+    }
+
     @Operation(summary = "게시물 리스트 API")
     @GetMapping("/{boardType}/{categoryType}")
     //TODO status에 따른 title, content 변경

--- a/src/main/java/community/mingle/api/domain/post/facade/PostFacade.java
+++ b/src/main/java/community/mingle/api/domain/post/facade/PostFacade.java
@@ -105,6 +105,17 @@ public class PostFacade {
                 .build();
     }
 
+    public PostListResponse getAllPostList(BoardType boardType, PageRequest pageRequest) {
+        Long memberId = tokenService.getTokenInfo().getMemberId();
+        List<Post> postList = postService.pagePostsByBoardType(boardType, pageRequest);
+
+        List<PostPreviewDto> postPreviewDtoList = postList.stream()
+                .map(post -> mapToPostPreviewResponse(post, memberId))
+                .collect(Collectors.toList());
+        return new PostListResponse(postPreviewDtoList);
+    }
+
+
     public PostListResponse getPostList(BoardType boardType, CategoryType categoryType, PageRequest pageRequest) {
         Long memberId = tokenService.getTokenInfo().getMemberId();
         List<Post> postList = postService.pagePostsByBoardTypeAndCategory(boardType, categoryType, pageRequest);

--- a/src/main/java/community/mingle/api/domain/post/repository/PostRepository.java
+++ b/src/main/java/community/mingle/api/domain/post/repository/PostRepository.java
@@ -12,4 +12,6 @@ import org.springframework.stereotype.Repository;
 public interface PostRepository extends JpaRepository<Post, Long>{
 
     public Page<Post> findAllByBoardTypeAndCategoryType(BoardType boardType, CategoryType categoryType, PageRequest pageRequest);
+
+    Page<Post> findAllByBoardType(BoardType boardType, PageRequest pageRequest);
 }

--- a/src/main/java/community/mingle/api/domain/post/service/PostService.java
+++ b/src/main/java/community/mingle/api/domain/post/service/PostService.java
@@ -90,6 +90,12 @@ public class PostService {
                 .orElse(null);
     }
 
+
+    public List<Post> pagePostsByBoardType(BoardType boardType, PageRequest pageRequest) {
+        Page<Post> pagePosts = postRepository.findAllByBoardType(boardType, pageRequest);
+        return pagePosts.toList();
+    }
+
     public List<Post> pagePostsByBoardTypeAndCategory(BoardType boardType, CategoryType categoryType, PageRequest pageRequest) {
         Page<Post> pagePosts = postRepository.findAllByBoardTypeAndCategoryType(boardType, categoryType, pageRequest);
         return pagePosts.toList();


### PR DESCRIPTION
/post/{boardType} 까지만 하고싶었는데 그러면 /post/{postId} 와 겹치고 스프링에서 Long과 enum 타입을 구분하지 못한다해서 어쩔 수 없이 뒤에 /all을 붙였습니다. 

더 좋은 uri가 있으면 서제션 부탁드려용