### PR TITLE
조회수 증가 로직을 비동기로 처리

### DIFF
--- a/src/main/java/community/mingle/api/domain/post/entity/PostViewCountSession.java
+++ b/src/main/java/community/mingle/api/domain/post/entity/PostViewCountSession.java
@@ -1,0 +1,44 @@
+package community.mingle.api.domain.post.entity;
+
+import community.mingle.api.domain.member.entity.Member;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "post_view_count_session")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class PostViewCountSession {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @NotNull
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @NotNull
+    @Column(name = "last_view_at", nullable = false)
+    private LocalDateTime lastViewAt;
+
+    public void updateLastViewAt() {
+        this.lastViewAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/community/mingle/api/domain/post/event/PostEventHandler.java
+++ b/src/main/java/community/mingle/api/domain/post/event/PostEventHandler.java
@@ -1,0 +1,46 @@
+package community.mingle.api.domain.post.event;
+
+import community.mingle.api.domain.post.entity.Post;
+import community.mingle.api.domain.post.entity.PostViewCountSession;
+import community.mingle.api.domain.post.service.PostService;
+import lombok.AllArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Component
+@AllArgsConstructor
+@EnableAsync
+public class PostEventHandler {
+
+    private final PostService postService;
+    private static final Long SESSION_LIVE_LIMIT = 60L;
+
+    @EventListener(ReadPostEvent.class)
+    @Async
+    @Transactional
+    public void handleReadPostEvent(ReadPostEvent event) {
+        Optional<PostViewCountSession> postViewCountSession = postService.getPostViewCountSessionByMemberIdAndPostId(
+                event.getMemberId(), event.getPostId()
+        );
+        Post post = postService.getPost(event.getPostId());
+        postViewCountSession.ifPresentOrElse(
+                session -> {
+                    if (session.getMember().getId().equals(event.getMemberId()) && session.getPost().getId().equals(event.getPostId())) {
+                        if (session.getLastViewAt().plusSeconds(SESSION_LIVE_LIMIT).isBefore(LocalDateTime.now())) {
+                            session.updateLastViewAt();
+                            postService.updateView(post);
+                        }
+                    }
+                },
+                () -> {
+                    postService.createPostViewCountSession(event.getMemberId(), event.getPostId());
+                    postService.updateView(post);
+                });
+    }
+}

--- a/src/main/java/community/mingle/api/domain/post/event/ReadPostEvent.java
+++ b/src/main/java/community/mingle/api/domain/post/event/ReadPostEvent.java
@@ -1,0 +1,15 @@
+package community.mingle.api.domain.post.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class ReadPostEvent extends ApplicationEvent {
+    private final Long postId;
+    private final Long memberId;
+    public ReadPostEvent(Object source, Long postId, Long memberId) {
+        super(source);
+        this.postId = postId;
+        this.memberId = memberId;
+    }
+}

--- a/src/main/java/community/mingle/api/domain/post/facade/PostFacade.java
+++ b/src/main/java/community/mingle/api/domain/post/facade/PostFacade.java
@@ -10,6 +10,7 @@ import community.mingle.api.domain.post.controller.request.CreatePostRequest;
 import community.mingle.api.domain.post.controller.request.UpdatePostRequest;
 import community.mingle.api.domain.post.controller.response.*;
 import community.mingle.api.domain.post.entity.Post;
+import community.mingle.api.domain.post.event.ReadPostEvent;
 import community.mingle.api.domain.post.service.PostImageService;
 import community.mingle.api.domain.post.service.PostLikeService;
 import community.mingle.api.domain.post.service.PostScrapService;
@@ -190,7 +191,9 @@ public class PostFacade {
         Long memberId = tokenService.getTokenInfo().getMemberId();
         Post post = postService.getPost(postId);
 
-        postService.updateView(post);
+        applicationEventPublisher.publishEvent(
+                new ReadPostEvent(this, postId, memberId)
+        );
 
         return mapToPostDetailResponse(post, memberId);
     }

--- a/src/main/java/community/mingle/api/domain/post/repository/PostViewCountSessionRepository.java
+++ b/src/main/java/community/mingle/api/domain/post/repository/PostViewCountSessionRepository.java
@@ -1,0 +1,13 @@
+package community.mingle.api.domain.post.repository;
+
+import community.mingle.api.domain.post.entity.PostViewCountSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PostViewCountSessionRepository extends JpaRepository<PostViewCountSession, Long> {
+    public Optional<PostViewCountSession> findByMemberIdAndPostId(Long memberId, Long postId);
+
+}

--- a/src/main/java/community/mingle/api/domain/post/service/PostService.java
+++ b/src/main/java/community/mingle/api/domain/post/service/PostService.java
@@ -5,6 +5,7 @@ import community.mingle.api.domain.member.entity.Member;
 import community.mingle.api.domain.member.repository.MemberRepository;
 import community.mingle.api.domain.post.entity.Post;
 import community.mingle.api.domain.post.entity.PostImage;
+import community.mingle.api.domain.post.entity.PostViewCountSession;
 import community.mingle.api.domain.post.repository.*;
 import community.mingle.api.domain.report.entity.PostReport;
 import community.mingle.api.domain.report.entity.Report;
@@ -19,6 +20,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -36,6 +38,7 @@ public class PostService {
     private final PostScrapRepository postScrapRepository;
     private final PostReportRepository postReportRepository;
     private final PostQueryRepository postQueryRepository;
+    private final PostViewCountSessionRepository postViewCountSessionRepository;
 
     @Transactional
     public Post createPost(
@@ -227,10 +230,31 @@ public class PostService {
         return post;
     }
 
-
     public List<Post> getPostByKeyword(String keyword, Long viewerMemberId, PageRequest pageRequest) {
         Member viewerMember = memberRepository.findById(viewerMemberId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
         return postQueryRepository.findSearchPosts(keyword, viewerMember, pageRequest).toList();
+    }
+
+    public Optional<PostViewCountSession> getPostViewCountSessionByMemberIdAndPostId(
+            Long memberId,
+            Long postId
+    ) {
+        return postViewCountSessionRepository.findByMemberIdAndPostId(memberId, postId);
+    }
+
+    public void createPostViewCountSession(
+            Long memberId,
+            Long postId
+    ) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        Post post = postRepository.findById(postId).orElseThrow();
+        PostViewCountSession postViewCountSession = PostViewCountSession.builder()
+                .member(member)
+                .post(post)
+                .createdAt(LocalDateTime.now())
+                .lastViewAt(LocalDateTime.now())
+                .build();
+        postViewCountSessionRepository.save(postViewCountSession);
     }
 
 }

--- a/src/main/resources/db/changelog/changelog-0038.yml
+++ b/src/main/resources/db/changelog/changelog-0038.yml
@@ -1,0 +1,48 @@
+databaseChangeLog:
+  - changeSet:
+      id: add member post view count session
+      author: Hyeonwoo Jung
+      changes:
+        - createTable:
+            tableName: post_view_count_session
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+                  autoIncrement: true
+              - column:
+                  name: member_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: post_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: last_view_at
+                  type: timestamp
+                  constraints:
+                    nullable: false
+
+        - addForeignKeyConstraint:
+            baseTableName: post_view_count_session
+            baseColumnNames: member_id
+            referencedTableName: member
+            referencedColumnNames: id
+            constraintName: post_view_count_session_member_id_fk
+        - addForeignKeyConstraint:
+            baseTableName: post_view_count_session
+            baseColumnNames: post_id
+            referencedTableName: post
+            referencedColumnNames: id
+            constraintName: post_view_count_session_post_id_fk


### PR DESCRIPTION
### As-Is
- 기존 로직은 새로고침할 때 마다 조회수가 올라갔음
- 유저들이 조회수 어뷰징 할 가능성 + 조회수의 신뢰도가 떨어짐
- 조회수 증가 update 시간이 게시물 가져오는데 영향을 미침

### To-Be
- 조회수 증가 로직을 비동기로 처리해서 게시글 조회 로직과의 영향도를 낮춤
- post_view_count_sesstion 을 두어서 한 번 조회하면 특정 시간 (1분) 동안은 조회수 카운트가 오르지 않도록 로직 변경