### PR TITLE
잔디밭에서 유저 학교에 따른 게시물만 보여주기

### DIFF
--- a/src/main/java/community/mingle/api/domain/post/facade/PostFacade.java
+++ b/src/main/java/community/mingle/api/domain/post/facade/PostFacade.java
@@ -115,7 +115,8 @@ public class PostFacade {
 
     public PostListResponse getAllPostList(BoardType boardType, PageRequest pageRequest) {
         Long memberId = tokenService.getTokenInfo().getMemberId();
-        List<Post> postList = postService.pagePostsByBoardType(boardType, pageRequest);
+        Member member = memberService.getById(memberId);
+        List<Post> postList = postService.pagePostsByBoardType(boardType, pageRequest, member.getUniversity().getId());
 
         List<PostPreviewDto> postPreviewDtoList = postList.stream()
                 .map(post -> mapToPostPreviewResponse(post, memberId))
@@ -126,7 +127,8 @@ public class PostFacade {
 
     public PostListResponse getPostList(BoardType boardType, CategoryType categoryType, PageRequest pageRequest) {
         Long memberId = tokenService.getTokenInfo().getMemberId();
-        List<Post> postList = postService.pagePostsByBoardTypeAndCategory(boardType, categoryType, pageRequest);
+        Member member = memberService.getById(memberId);
+        List<Post> postList = postService.pagePostsByBoardTypeAndCategory(boardType, categoryType, pageRequest, member.getUniversity().getId());
 
         List<PostPreviewDto> postPreviewDtoList = postList.stream()
                 .map(post -> mapToPostPreviewResponse(post, memberId))

--- a/src/main/java/community/mingle/api/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/community/mingle/api/domain/post/repository/PostQueryRepository.java
@@ -44,6 +44,7 @@ public class PostQueryRepository {
                                 .or(
                                         postLikeCountGreaterThanOrEqual(BEST_UNIV_POST_LIKE_COUNT)
                                                 .and(post.boardType.eq(BoardType.UNIV))
+                                                .and(post.member.university.id.eq(viewerMember.getUniversity().getId()))
                                 ),
                         viewablePostCondition(post, viewerMember)
                 )
@@ -75,7 +76,11 @@ public class PostQueryRepository {
                 .from(post)
                 .join(post.member, member)
                 .where(
-                        post.boardType.eq(boardType),
+                        post.boardType.eq(boardType)
+                                .and(
+                                        post.boardType.ne(BoardType.UNIV)
+                                                .or(post.member.university.id.eq(viewMember.getUniversity().getId()))
+                                ),
                         viewablePostCondition(post, viewMember)
 
                 )

--- a/src/main/java/community/mingle/api/domain/post/repository/PostRepository.java
+++ b/src/main/java/community/mingle/api/domain/post/repository/PostRepository.java
@@ -15,6 +15,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     public Page<Post> findAllByBoardTypeAndCategoryType(BoardType boardType, CategoryType categoryType, PageRequest pageRequest);
 
+    public Page<Post> findAllByBoardTypeAndCategoryTypeAndMemberUniversityId(BoardType boardType, CategoryType categoryType, PageRequest pageRequest, int memberId);
+
     Page<Post> findAllByBoardTypeAndMember(BoardType boardType, Member member, PageRequest pageRequest);
 
     @Query("select distinct p from Comment c join c.member m join c.post p where m.id = :memberId and p.boardType = :boardType")
@@ -27,4 +29,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAllByLikeMemberIdAndBoardType(Long memberId, BoardType boardType, PageRequest pageRequest);
 
     Page<Post> findAllByBoardType(BoardType boardType, PageRequest pageRequest);
+
+    Page<Post> findAllByBoardTypeAndMemberUniversityId(BoardType boardType, PageRequest pageRequest, int universityId);
 }

--- a/src/main/java/community/mingle/api/domain/post/service/PostService.java
+++ b/src/main/java/community/mingle/api/domain/post/service/PostService.java
@@ -25,8 +25,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static community.mingle.api.enums.ContentStatusType.REPORTED;
-import static community.mingle.api.global.exception.ErrorCode.MEMBER_NOT_FOUND;
-import static community.mingle.api.global.exception.ErrorCode.POST_NOT_EXIST;
+import static community.mingle.api.global.exception.ErrorCode.*;
 
 
 @Service
@@ -71,11 +70,13 @@ public class PostService {
                 .orElseThrow(() -> new CustomException(POST_NOT_EXIST));
     }
 
+    //TODO 광장, 잔디밭 구분해서 잔디밭일 경우 학교별로 필터링하는 로직 팩토리 메소드로 구현하기
     public Page<Post> getBestPostList(Long viewerMemberId, PageRequest pageRequest) {
         Member viewerMember = memberRepository.findById(viewerMemberId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
         return postQueryRepository.pageBestPosts(viewerMember, pageRequest);
     }
 
+    //TODO 광장, 잔디밭 구분해서 잔디밭일 경우 학교별로 필터링하는 로직 팩토리 메소드로 구현하기
     public List<Post> getRecentPostList(BoardType boardType, Long memberId) {
         Member viewMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
@@ -96,13 +97,29 @@ public class PostService {
     }
 
 
-    public List<Post> pagePostsByBoardType(BoardType boardType, PageRequest pageRequest) {
-        Page<Post> pagePosts = postRepository.findAllByBoardType(boardType, pageRequest);
+    //TODO 광장, 잔디밭 구분해서 잔디밭일 경우 학교별로 필터링하는 로직 팩토리 메소드로 구현하기
+    public List<Post> pagePostsByBoardType(BoardType boardType, PageRequest pageRequest, int universityId) {
+        Page<Post> pagePosts;
+        switch (boardType) {
+            case TOTAL -> pagePosts = postRepository.findAllByBoardType(boardType, pageRequest);
+            case UNIV ->
+                    pagePosts = postRepository.findAllByBoardTypeAndMemberUniversityId(boardType, pageRequest, universityId);
+            default -> throw new CustomException(INTERNAL_SERVER_ERROR);
+        }
+
         return pagePosts.toList();
     }
 
-    public List<Post> pagePostsByBoardTypeAndCategory(BoardType boardType, CategoryType categoryType, PageRequest pageRequest) {
-        Page<Post> pagePosts = postRepository.findAllByBoardTypeAndCategoryType(boardType, categoryType, pageRequest);
+    //TODO 광장, 잔디밭 구분해서 잔디밭일 경우 학교별로 필터링하는 로직 팩토리 메소드로 구현하기
+    public List<Post> pagePostsByBoardTypeAndCategory(BoardType boardType, CategoryType categoryType, PageRequest pageRequest, int universityId) {
+        Page<Post> pagePosts;
+        switch (boardType) {
+            case TOTAL -> pagePosts = postRepository.findAllByBoardTypeAndCategoryType(boardType, categoryType, pageRequest);
+            case UNIV ->
+                    pagePosts = postRepository.findAllByBoardTypeAndCategoryTypeAndMemberUniversityId(boardType, categoryType, pageRequest, universityId);
+            default -> throw new CustomException(INTERNAL_SERVER_ERROR);
+        }
+
         return pagePosts.toList();
     }
 


### PR DESCRIPTION
### As-Is
- 잔디밭에서도 모든 학교의 게시물을 다 보여주고 있었음

### To-Be
- 잔디밭일 경우 유저의 학교별로 게시물을 필터링하는 로직 추가

### TODO
- 임시 구현으로 switch 문으로 각 메서드에 필터링 로직을 추가했지만, 장기적으로 혼란을 막기 위해 totalPostRepository와 univPostRepository를 따로 관리하여 팩토리 구현으로 boardType에 따라 맞는 repository를 사용하는 형태로 리펙토링 예상