### PR TITLE
fix: FCM 푸시알림 로직 기존 서버 로직으로 원복

### DIFF
--- a/src/main/java/community/mingle/api/domain/notification/event/NotificationEventHandler.java
+++ b/src/main/java/community/mingle/api/domain/notification/event/NotificationEventHandler.java
@@ -25,6 +25,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
 import java.util.List;
 
 
@@ -52,7 +53,7 @@ public class NotificationEventHandler {
     @EventListener(ManualNotificationEvent.class)
     @Async
     @Transactional
-    public void handleManualNotificationEvent(ManualNotificationEvent event) {
+    public void handleManualNotificationEvent(ManualNotificationEvent event) { //TODO 원복 + async 필요
         Post post = postService.getPost(event.getContentId());
         List<Member> targetMembers = notificationService.getTargetTokenMembersByBoardType(event.getBoardType(), post);
         fcmService.sendAllMessage(
@@ -71,7 +72,7 @@ public class NotificationEventHandler {
     @EventListener(CommentNotificationEvent.class)
     @Async
     @Transactional
-    public void handleCommentNotificationEvent(CommentNotificationEvent event) { //DONE
+    public void handleCommentNotificationEvent(CommentNotificationEvent event) throws IOException { // 푸시알림 로직 원복
         Post post = postService.getPost(event.getPostId());
         Member member = memberService.getById(event.getMemberId());
         Comment comment = commentService.getComment(event.getCommentId());
@@ -79,7 +80,7 @@ public class NotificationEventHandler {
         String body = COMMENT_NOTIFICATION_BODY + event.getContent();
 
         List<Member> targetMembers = notificationService.getTargetUserTokenMembersForComment(event.getParentCommentId(), event.getMentionId(), member, post);
-        fcmService.sendAllMessage(
+        fcmService.sendMessage(
                 title,
                 body,
                 post.getId(),
@@ -96,7 +97,7 @@ public class NotificationEventHandler {
     @EventListener(ItemCommentNotificationEvent.class)
     @Async
     @Transactional
-    public void handleItemCommentNotificationEvent(ItemCommentNotificationEvent event) { //DONE
+    public void handleItemCommentNotificationEvent(ItemCommentNotificationEvent event) throws IOException { //DONE
         String title = ITEM_COMMENT_NOTIFICATION_TITLE; //manual 푸시와 다르게 title, content를 event 정보로 생성
         String body = COMMENT_NOTIFICATION_BODY + event.getContent();
         Member member = memberService.getById(event.getMemberId());
@@ -105,7 +106,7 @@ public class NotificationEventHandler {
 
 
         List<Member> targetMembers = notificationService.getTargetUserTokenMembersForItemComment(event.getParentCommentId(), event.getMentionId(), member, item);
-        fcmService.sendAllMessage(
+        fcmService.sendMessage(
                 title,
                 body,
                 item.getId(),
@@ -122,14 +123,14 @@ public class NotificationEventHandler {
     @EventListener(PopularPostNotificationEvent.class)
     @Async
     @Transactional
-    public void handlePopularPostNotificationEvent(PopularPostNotificationEvent event) {
+    public void handlePopularPostNotificationEvent(PopularPostNotificationEvent event) throws IOException {
         Post post = postService.getPost(event.getPostId());
 
         String title = post.getBoardType().name();
         String body = POPULAR_NOTIFICATION_BODY;
 
         List<Member> targetMembers = List.of(post.getMember());
-        fcmService.sendAllMessage(
+        fcmService.sendMessage(
                 title,
                 body,
                 event.getPostId(),

--- a/src/main/java/community/mingle/api/global/firebase/FcmMessage.java
+++ b/src/main/java/community/mingle/api/global/firebase/FcmMessage.java
@@ -1,0 +1,41 @@
+package community.mingle.api.global.firebase;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class FcmMessage {
+    private boolean validate_only;
+    private Message message;
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class Message {
+        private Notification notification;
+        private Data data;
+        private String token;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class Notification {
+        private String title;
+        private String body;
+        private String image;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class Data {
+        private String contentType;
+        private String categoryType;
+        private String postId;
+    }
+
+}

--- a/src/main/java/community/mingle/api/global/firebase/FcmService.java
+++ b/src/main/java/community/mingle/api/global/firebase/FcmService.java
@@ -1,13 +1,21 @@
 package community.mingle.api.global.firebase;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.MulticastMessage;
 import com.google.firebase.messaging.Notification;
 import community.mingle.api.enums.ContentType;
+import community.mingle.api.infra.SecretsManagerService;
 import lombok.RequiredArgsConstructor;
+import okhttp3.*;
 import org.springframework.stereotype.Component;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 
 @Component
@@ -16,6 +24,10 @@ public class FcmService {
 
     private static final int BATCH_SIZE = 500;
     private final FirebaseApp firebaseApp;
+    private final ObjectMapper objectMapper;
+    private final SecretsManagerService secretsManagerService;
+    private final String profile;
+    private final String API_URL = "https://fcm.googleapis.com/v1/projects/mingle-new/messages:send"; //dev
 
     public void sendAllMessage(String title, String body, Long contentId, ContentType contentType, List<String> allTokens) {
         int total = allTokens.size();
@@ -26,6 +38,41 @@ public class FcmService {
             FirebaseMessaging.getInstance(firebaseApp).sendMulticastAsync(messages);
             count += BATCH_SIZE;
         }
+    }
+
+    public void sendMessage(String title, String body, Long contentId, ContentType contentType, List<String> allTokens) throws IOException {
+        String message = makeMessage(allTokens.get(0), contentType,  title, body, contentId);
+        OkHttpClient client = new OkHttpClient();
+        RequestBody requestBody = RequestBody.create(message, MediaType.get("application/json; charset=utf-8"));
+        Request request = new Request.Builder().url(API_URL).post(requestBody).addHeader("AUTHORIZATION", "Bearer " + getAccessToken())
+                .addHeader("CONTENT_TYPE", "application/json; UTF-8")
+                .build();
+        Response response = client.newCall(request).execute();
+        System.out.println(response.body().string());
+    }
+
+    private String makeMessage(String targetToken, ContentType contentType, String title, String body, Long postId) throws JsonProcessingException {
+        FcmMessage fcmMessage = FcmMessage.builder()
+                .message(FcmMessage.Message.builder().token(targetToken)
+                        .notification(FcmMessage.Notification.builder().title(title).body(body).image(null).build())
+                        .data(FcmMessage.Data.builder().
+                                contentType(contentType.name()).
+                                postId(String.valueOf(postId)).build())
+                        .build())
+                .validate_only(false).build();
+        return objectMapper.writeValueAsString(fcmMessage);
+    }
+
+    private String getAccessToken() throws IOException {
+        InputStream firebaseToken = convertToStream(secretsManagerService.getFcmToken(profile));
+        GoogleCredentials googleCredentials = GoogleCredentials.fromStream(firebaseToken)
+                .createScoped(List.of("https://www.googleapis.com/auth/cloud-platform"));
+        googleCredentials.refreshIfExpired();
+        return googleCredentials.getAccessToken().getTokenValue();
+    }
+
+    private InputStream convertToStream(String token) {
+        return new ByteArrayInputStream(token.getBytes());
     }
 
     public MulticastMessage buildMessage(String title, String body, Long contentId, ContentType contentType, List<String> fcmTokens) {


### PR DESCRIPTION
- 기존 밍글 서버에서 사용하던 FCM 로직으로 원복
- 게시물 댓글, 인기게시물, 장터 댓글 알림 반영 완료
- manual 대량 푸시는 시간 단축할 대안 찾아 적용 필요