### PR TITLE
[DEV-321] PersonalCourse 추가 양방향 매핑 버그 수정

### DIFF
--- a/src/main/java/community/mingle/api/domain/course/entity/Course.java
+++ b/src/main/java/community/mingle/api/domain/course/entity/Course.java
@@ -88,4 +88,14 @@ public class Course extends AuditLoggingBase {
     @Cascade(CascadeType.ALL)
     List<CourseTimetable> courseTimetableList = new ArrayList<>();
 
+    public void setCourseTimeList(List<CourseTime> courseTimeList) {
+        this.courseTimeList = courseTimeList;
+    }
+
+    public void updateCourseTimetable(CourseTimetable courseTimetable) {
+        if (courseTimetableList == null) {
+            this.courseTimetableList = List.of(courseTimetable);
+        } else this.courseTimetableList.add(courseTimetable);
+    }
+
 }

--- a/src/main/java/community/mingle/api/domain/course/service/CourseService.java
+++ b/src/main/java/community/mingle/api/domain/course/service/CourseService.java
@@ -54,7 +54,9 @@ public class CourseService {
 
         PersonalCourse personalCourse = personalCourseRepository.save(course);
 
-        createCourseTime(personalCourse.getId(), courseTimeDtoList);
+        List<CourseTime> courseTimeList = createCourseTime(personalCourse.getId(), courseTimeDtoList);
+
+        personalCourse.setCourseTimeList(courseTimeList);
 
         return personalCourse;
     }

--- a/src/main/java/community/mingle/api/domain/course/service/TimetableService.java
+++ b/src/main/java/community/mingle/api/domain/course/service/TimetableService.java
@@ -74,7 +74,11 @@ public class TimetableService {
                 .course(course)
                 .rgb(rgb.getStringRgb())
                 .build();
-        return courseTimetableRepository.save(courseTimetable);
+
+        courseTimetableRepository.save(courseTimetable);
+        course.updateCourseTimetable(courseTimetable);
+
+        return courseTimetable;
     }
 
     @Transactional


### PR DESCRIPTION
- jpa 에서 cascade 옵션은 켜져있었지만, persist 되기 전에는 부모 엔티티를 통해 자식 엔티티를 가져오려고해도 null 이 발생했음
- 일단 부모 엔티티에 수동으로 자식 엔티티 리스트를 넣어줌으로써 해결했지만, 관련 추가 리서치 필요