### PR TITLE
강의평가 노출 여부 필드 추가

### DIFF
--- a/src/main/java/community/mingle/api/domain/auth/controller/response/VerifyLoggedInMemberResponse.java
+++ b/src/main/java/community/mingle/api/domain/auth/controller/response/VerifyLoggedInMemberResponse.java
@@ -5,6 +5,7 @@ public record VerifyLoggedInMemberResponse(
         String hashedEmail,
         String nickName,
         String univName,
-        String country
+        String country,
+        Boolean isCourseEvaluationAllowed
 ) {
 }

--- a/src/main/java/community/mingle/api/domain/auth/facade/AuthFacade.java
+++ b/src/main/java/community/mingle/api/domain/auth/facade/AuthFacade.java
@@ -17,7 +17,6 @@ import community.mingle.api.domain.auth.controller.response.VerifyLoggedInMember
 import community.mingle.api.domain.auth.entity.Policy;
 import community.mingle.api.domain.auth.service.AuthService;
 import community.mingle.api.domain.auth.service.TokenService;
-import community.mingle.api.domain.backoffice.controller.response.FreshmanCouponApplyListResponse;
 import community.mingle.api.domain.backoffice.controller.response.TempSignUpApplyListResponse;
 import community.mingle.api.domain.backoffice.controller.response.TempSignUpApplyResponse;
 import community.mingle.api.domain.member.entity.Member;
@@ -52,6 +51,9 @@ public class AuthFacade {
     private final TokenService tokenService;
     private final S3Service s3Service;
     private final MemberAuthPhotoService memberAuthPhotoService;
+
+    //HKU, HKUST, CITYU, POLYU, NUS, NTU
+    private final List<Integer> courseEvaluationAllowed = List.of(1, 2, 4, 5, 7, 8);
 
     public VerifyEmailResponse verifyEmail(EmailRequest emailRequest) {
         authService.verifyEmail(emailRequest.getEmail());
@@ -204,12 +206,14 @@ public class AuthFacade {
     public VerifyLoggedInMemberResponse getVerifiedMemberInfo() {
         Long memberIdByJwt = tokenService.getTokenInfo().getMemberId();
         Member member = memberService.getById(memberIdByJwt);
+        boolean isCourseEvaluationAllowed = courseEvaluationAllowed.contains(member.getUniversity().getId());
         return new VerifyLoggedInMemberResponse(
                 member.getId(),
                 member.getEmail(),
                 member.getNickname(),
                 member.getUniversity().getName(),
-                member.getUniversity().getCountry().getName()
+                member.getUniversity().getCountry().getName(),
+                isCourseEvaluationAllowed
         );
     }
 


### PR DESCRIPTION
### Context
- 유저 메타데이터를 담는 api응답 (로그인 여부 확인 api)에 강의평가 노출 여부를 결정하는 필드 추가
- 강의평가를 위해서 모든 학교를 크롤링하기에는 효용성이 떨어진다고 판단하여, 유저가 많거나 강의 크롤링이 쉬운 학교들 대상으로 우선 강의평가 시스템을 서비스하기로 결정
- 강의평가 서비스를 하는 학교 학생에게만 강의평가 페이지 접근 버튼을 노출하기 위한 필드 추가 작업임